### PR TITLE
Auto Tagging Support Tickets Using LLM

### DIFF
--- a/Auto Tagging Support Tickets Using LLM .ipynb
+++ b/Auto Tagging Support Tickets Using LLM .ipynb
@@ -1,0 +1,337 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "252503e1-d088-4a71-844a-ad46dda79ae3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: torch in c:\\users\\user\\anaconda3\\lib\\site-packages (2.7.1)\n",
+      "Requirement already satisfied: torchvision in c:\\users\\user\\anaconda3\\lib\\site-packages (0.22.1)\n",
+      "Requirement already satisfied: torchaudio in c:\\users\\user\\anaconda3\\lib\\site-packages (2.7.1)\n",
+      "Requirement already satisfied: filelock in c:\\users\\user\\anaconda3\\lib\\site-packages (from torch) (3.13.1)\n",
+      "Requirement already satisfied: typing-extensions>=4.10.0 in c:\\users\\user\\anaconda3\\lib\\site-packages (from torch) (4.11.0)\n",
+      "Requirement already satisfied: sympy>=1.13.3 in c:\\users\\user\\anaconda3\\lib\\site-packages (from torch) (1.14.0)\n",
+      "Requirement already satisfied: networkx in c:\\users\\user\\anaconda3\\lib\\site-packages (from torch) (3.3)\n",
+      "Requirement already satisfied: jinja2 in c:\\users\\user\\appdata\\roaming\\python\\python312\\site-packages (from torch) (3.1.6)\n",
+      "Requirement already satisfied: fsspec in c:\\users\\user\\anaconda3\\lib\\site-packages (from torch) (2024.6.1)\n",
+      "Requirement already satisfied: setuptools in c:\\users\\user\\anaconda3\\lib\\site-packages (from torch) (75.1.0)\n",
+      "Requirement already satisfied: numpy in c:\\users\\user\\anaconda3\\lib\\site-packages (from torchvision) (1.26.4)\n",
+      "Requirement already satisfied: pillow!=8.3.*,>=5.3.0 in c:\\users\\user\\anaconda3\\lib\\site-packages (from torchvision) (10.4.0)\n",
+      "Requirement already satisfied: mpmath<1.4,>=1.1.0 in c:\\users\\user\\anaconda3\\lib\\site-packages (from sympy>=1.13.3->torch) (1.3.0)\n",
+      "Requirement already satisfied: MarkupSafe>=2.0 in c:\\users\\user\\appdata\\roaming\\python\\python312\\site-packages (from jinja2->torch) (3.0.2)\n",
+      "Requirement already satisfied: transformers in c:\\users\\user\\anaconda3\\lib\\site-packages (4.54.0)\n",
+      "Requirement already satisfied: filelock in c:\\users\\user\\anaconda3\\lib\\site-packages (from transformers) (3.13.1)\n",
+      "Requirement already satisfied: huggingface-hub<1.0,>=0.34.0 in c:\\users\\user\\anaconda3\\lib\\site-packages (from transformers) (0.34.1)\n",
+      "Requirement already satisfied: numpy>=1.17 in c:\\users\\user\\anaconda3\\lib\\site-packages (from transformers) (1.26.4)\n",
+      "Requirement already satisfied: packaging>=20.0 in c:\\users\\user\\anaconda3\\lib\\site-packages (from transformers) (24.1)\n",
+      "Requirement already satisfied: pyyaml>=5.1 in c:\\users\\user\\appdata\\roaming\\python\\python312\\site-packages (from transformers) (6.0.2)\n",
+      "Requirement already satisfied: regex!=2019.12.17 in c:\\users\\user\\anaconda3\\lib\\site-packages (from transformers) (2024.9.11)\n",
+      "Requirement already satisfied: requests in c:\\users\\user\\appdata\\roaming\\python\\python312\\site-packages (from transformers) (2.32.3)\n",
+      "Requirement already satisfied: tokenizers<0.22,>=0.21 in c:\\users\\user\\anaconda3\\lib\\site-packages (from transformers) (0.21.2)\n",
+      "Requirement already satisfied: safetensors>=0.4.3 in c:\\users\\user\\anaconda3\\lib\\site-packages (from transformers) (0.5.3)\n",
+      "Requirement already satisfied: tqdm>=4.27 in c:\\users\\user\\anaconda3\\lib\\site-packages (from transformers) (4.66.5)\n",
+      "Requirement already satisfied: fsspec>=2023.5.0 in c:\\users\\user\\anaconda3\\lib\\site-packages (from huggingface-hub<1.0,>=0.34.0->transformers) (2024.6.1)\n",
+      "Requirement already satisfied: typing-extensions>=3.7.4.3 in c:\\users\\user\\anaconda3\\lib\\site-packages (from huggingface-hub<1.0,>=0.34.0->transformers) (4.11.0)\n",
+      "Requirement already satisfied: colorama in c:\\users\\user\\appdata\\roaming\\python\\python312\\site-packages (from tqdm>=4.27->transformers) (0.4.6)\n",
+      "Requirement already satisfied: charset-normalizer<4,>=2 in c:\\users\\user\\appdata\\roaming\\python\\python312\\site-packages (from requests->transformers) (3.4.1)\n",
+      "Requirement already satisfied: idna<4,>=2.5 in c:\\users\\user\\appdata\\roaming\\python\\python312\\site-packages (from requests->transformers) (3.10)\n",
+      "Requirement already satisfied: urllib3<3,>=1.21.1 in c:\\users\\user\\anaconda3\\lib\\site-packages (from requests->transformers) (2.2.3)\n",
+      "Requirement already satisfied: certifi>=2017.4.17 in c:\\users\\user\\appdata\\roaming\\python\\python312\\site-packages (from requests->transformers) (2025.4.26)\n"
+     ]
+    }
+   ],
+   "source": [
+    "!pip install torch torchvision torchaudio\n",
+    "!pip install transformers\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3411c41e-ffa3-4243-b95f-19f28dc01132",
+   "metadata": {},
+   "source": [
+    "import libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "2488ced7-ed4f-485b-9fd4-435139caa36a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "from transformers import pipeline\n",
+    "import pandas as pd\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bf7ab317-77c6-473f-ae8d-fa243ede1ea4",
+   "metadata": {},
+   "source": [
+    "Define Candidate Tags"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "0e3c3c8e-ec65-423b-99a5-52a0ce1e9b96",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "labels = [\"Billing\", \"Technical Issue\", \"Account Management\", \"Login Problem\"]\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "962af5f8-dcc1-4a86-bddf-f0e6241f7b87",
+   "metadata": {},
+   "source": [
+    "Create a Sample Dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "823fe795-8935-4333-8b49-fe36578a29c4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Ticket ID</th>\n",
+       "      <th>Text</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "      <td>My internet is not working since yesterday.</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2</td>\n",
+       "      <td>I want to change my billing address.</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>3</td>\n",
+       "      <td>Getting login error on the mobile app.</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>4</td>\n",
+       "      <td>How to reset my password?</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   Ticket ID                                         Text\n",
+       "0          1  My internet is not working since yesterday.\n",
+       "1          2         I want to change my billing address.\n",
+       "2          3       Getting login error on the mobile app.\n",
+       "3          4                    How to reset my password?"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data = {\n",
+    "    \"Ticket ID\": [1, 2, 3, 4],\n",
+    "    \"Text\": [\n",
+    "        \"My internet is not working since yesterday.\",\n",
+    "        \"I want to change my billing address.\",\n",
+    "        \"Getting login error on the mobile app.\",\n",
+    "        \"How to reset my password?\"\n",
+    "    ]\n",
+    "}\n",
+    "\n",
+    "df = pd.DataFrame(data)\n",
+    "df\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e25f999c-a28d-410b-a399-e4e6a9c85d5a",
+   "metadata": {},
+   "source": [
+    "Load the Zero-Shot Classification Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "01299f4b-0d65-4daa-9b17-9e4c85910697",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Device set to use cpu\n"
+     ]
+    }
+   ],
+   "source": [
+    "classifier = pipeline(\"zero-shot-classification\", model=\"facebook/bart-large-mnli\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "be67b7cf-ec6f-490c-8639-bf71cd413146",
+   "metadata": {},
+   "source": [
+    "Classify Each Ticket and Predict Tags"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "6354774b-d0aa-4efb-87f1-7e7330a0bf49",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Ticket ID</th>\n",
+       "      <th>Text</th>\n",
+       "      <th>Top Tags</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "      <td>My internet is not working since yesterday.</td>\n",
+       "      <td>[Technical Issue, Login Problem, Billing]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2</td>\n",
+       "      <td>I want to change my billing address.</td>\n",
+       "      <td>[Billing, Account Management, Technical Issue]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>3</td>\n",
+       "      <td>Getting login error on the mobile app.</td>\n",
+       "      <td>[Login Problem, Technical Issue, Billing]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>4</td>\n",
+       "      <td>How to reset my password?</td>\n",
+       "      <td>[Login Problem, Technical Issue, Account Manag...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   Ticket ID                                         Text  \\\n",
+       "0          1  My internet is not working since yesterday.   \n",
+       "1          2         I want to change my billing address.   \n",
+       "2          3       Getting login error on the mobile app.   \n",
+       "3          4                    How to reset my password?   \n",
+       "\n",
+       "                                            Top Tags  \n",
+       "0          [Technical Issue, Login Problem, Billing]  \n",
+       "1     [Billing, Account Management, Technical Issue]  \n",
+       "2          [Login Problem, Technical Issue, Billing]  \n",
+       "3  [Login Problem, Technical Issue, Account Manag...  "
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "def classify_ticket(text):\n",
+    "    result = classifier(text, candidate_labels=labels)\n",
+    "    return result[\"labels\"][:3]  # Top 3 predicted tags\n",
+    "\n",
+    "# Apply to all tickets\n",
+    "df[\"Top Tags\"] = df[\"Text\"].apply(classify_ticket)\n",
+    "df\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "365a61b7-ea36-483a-a0f9-2e9acc752a8f",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [conda env:base] *",
+   "language": "python",
+   "name": "conda-base-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
# Task 5: Auto Tagging Support Tickets Using LLM

## 🎯 Objective
Automatically tag free-text support tickets into relevant categories using a zero-shot large language model.

## 🧰 Tools
- Python
- Hugging Face Transformers
- PyTorch
- Jupyter Notebook

## 🛠️ Steps
1. Created a sample dataset of support tickets.
2. Defined labels: Billing, Technical Issue, etc.
3. Used `facebook/bart-large-mnli` in zero-shot mode.
4. Applied classifier to each ticket.
5. Exported the predictions.